### PR TITLE
Inline remaining_questions variable in start_new_block

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -111,8 +111,7 @@ impl MemoryPracticeApp {
         let mut questions = self.service.fetch_due_reviews();
 
         // Generate new questions to fill the block
-        let remaining_questions = self.questions_per_block.saturating_sub(questions.len());
-        let mut new_questions = generate_question_block(remaining_questions);
+        let mut new_questions = generate_question_block(self.questions_per_block.saturating_sub(questions.len()));
         questions.append(&mut new_questions);
 
         // If we have fewer questions than requested, generate more


### PR DESCRIPTION
Refactored start_new_block method to inline the remaining_questions
variable as it was only used once. This simplifies the code while
maintaining the exact same functionality. All tests pass.

Fixes #1
